### PR TITLE
Implemented log using defmt for LPC55

### DIFF
--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -11,6 +11,8 @@ embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", fe
 embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 lpc55-pac = "0.5.0"
 defmt = { version = "1", optional = true }
+log = "0.4.27"
+log-to-defmt = { version = "0.1.0", optional = true}
 
 [features]
 default = ["rt"]
@@ -18,3 +20,6 @@ rt = ["lpc55-pac/rt"]
 
 ## Enable [defmt support](https://docs.rs/defmt) and enables `defmt` debug-log messages and formatting in embassy drivers.
 defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt"]
+## Enable debug logs
+log-to-defmt = ["dep:log-to-defmt"]
+

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -3,7 +3,6 @@
 pub mod gpio;
 mod pac_utils;
 pub mod pint;
-
 pub use embassy_hal_internal::Peri;
 pub use lpc55_pac as pac;
 
@@ -15,7 +14,9 @@ pub use lpc55_pac as pac;
 pub fn init(_config: config::Config) -> Peripherals {
     gpio::init();
     pint::init();
-
+    #[cfg(feature = "log-to-defmt")]
+    log_to_defmt::setup();
+    log::info!("Initialization complete");
     crate::Peripherals::take()
 }
 

--- a/examples/lpc55s69/Cargo.toml
+++ b/examples/lpc55s69/Cargo.toml
@@ -18,5 +18,9 @@ defmt-rtt = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 panic-semihosting = "0.6.0"
 
+[features]
+## To test all-logs mode
+log-to-defmt = ["embassy-nxp/log-to-defmt"]
+
 [profile.release]
 debug = 2


### PR DESCRIPTION
Added `log-to-defmt` feature to `embassy-nxp`

Closes issue #4 