### PR TITLE
Tracking: upstream changes

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -262,6 +262,7 @@ cargo batch \
     --- build --release --manifest-path examples/stm32wba/Cargo.toml --target thumbv8m.main-none-eabihf --artifact-dir out/examples/stm32wba \
     --- build --release --manifest-path examples/stm32wl/Cargo.toml --target thumbv7em-none-eabi --artifact-dir out/examples/stm32wl \
     --- build --release --manifest-path examples/lpc55s69/Cargo.toml --target thumbv8m.main-none-eabihf --artifact-dir out/examples/lpc55s69 \
+    --- build --release --manifest-path examples/lpc55s69/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nxp/log-to-defmt --artifact-dir out/examples/lpc55s69 \    
     --- build --release --manifest-path examples/mspm0g3507/Cargo.toml --target thumbv6m-none-eabi --artifact-dir out/examples/mspm0g3507 \
     --- build --release --manifest-path examples/mspm0g3519/Cargo.toml --target thumbv6m-none-eabi --artifact-dir out/examples/mspm0g3519 \
     --- build --release --manifest-path examples/mspm0l1306/Cargo.toml --target thumbv6m-none-eabi --artifact-dir out/examples/mspm0l1306 \

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -11,6 +11,8 @@ embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", fe
 embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 lpc55-pac ={version="0.5.0", optional=true}
 defmt = { version = "1", optional = true }
+log = "0.4.27"
+log-to-defmt = { version = "0.1.0", optional = true}
 
 [features]
 default = ["rt"]
@@ -19,3 +21,6 @@ lpc55=["dep:lpc55-pac"]
 
 ## Enable [defmt support](https://docs.rs/defmt) and enables `defmt` debug-log messages and formatting in embassy drivers.
 defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt"]
+## Enable debug logs
+log-to-defmt = ["dep:log-to-defmt"]
+

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -9,12 +9,13 @@ cortex-m-rt = "0.7.0"
 critical-section = "1.1.2"
 embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-2"] }
 embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
-lpc55-pac = "0.5.0"
+lpc55-pac ={version="0.5.0", optional=true}
 defmt = { version = "1", optional = true }
 
 [features]
 default = ["rt"]
 rt = ["lpc55-pac/rt"]
+lpc55=["dep:lpc55-pac"]
 
 ## Enable [defmt support](https://docs.rs/defmt) and enables `defmt` debug-log messages and formatting in embassy drivers.
 defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt"]

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -19,6 +19,9 @@ pub fn init(_config: config::Config) -> Peripherals {
     crate::Peripherals::take()
 }
 
+#[cfg(not(any(feature = "lpc55")))]
+compile_error!("You must enable a Cargo feature. The only existent one for now is lpc55.");
+
 embassy_hal_internal::peripherals! {
     // External pins. These are not only GPIOs, they are multi-purpose pins and can be used by other
     // peripheral types (e.g. I2C).

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -3,7 +3,6 @@
 pub mod gpio;
 mod pac_utils;
 pub mod pint;
-
 pub use embassy_hal_internal::Peri;
 pub use lpc55_pac as pac;
 
@@ -15,7 +14,9 @@ pub use lpc55_pac as pac;
 pub fn init(_config: config::Config) -> Peripherals {
     gpio::init();
     pint::init();
-
+    #[cfg(feature = "log-to-defmt")]
+    log_to_defmt::setup();
+    log::info!("Initialization complete");
     crate::Peripherals::take()
 }
 

--- a/examples/lpc55s69/Cargo.toml
+++ b/examples/lpc55s69/Cargo.toml
@@ -18,5 +18,9 @@ defmt-rtt = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 panic-semihosting = "0.6.0"
 
+[features]
+## To test all-logs mode
+log-to-defmt = ["embassy-nxp/log-to-defmt"]
+
 [profile.release]
 debug = 2

--- a/examples/lpc55s69/Cargo.toml
+++ b/examples/lpc55s69/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["rt"] }
+embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features=["rt","lpc55"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }

--- a/examples/lpc55s69/src/bin/log_to_defmt.rs
+++ b/examples/lpc55s69/src/bin/log_to_defmt.rs
@@ -1,0 +1,18 @@
+/// To test log-to-defmt feature, you have to run the binary file with the corresponding flag
+/// Example: cargo run --bin <file> --feature log-to-defmt
+
+
+#![no_std]
+#![no_main]
+
+use log::*;
+use embassy_executor::Spawner;
+use {defmt_rtt as _, panic_halt as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Hello World");
+    loop{
+        info!("Another test");
+    }   
+}


### PR DESCRIPTION
 The project is still in its infancy so bigger and frequent PRs are to be expected. To keep our internal process clean (small, detailed PRs), to avoid spamming the upstream with smaller changes, and to resolve blocking changes faster internally we will merge to `lpc55-dev` branch instead of the upstream. 

This is a tracking PR that lets us monitor what changes we've implemented compared to the upstream. Every so often we should upstream our changes, if there are significant enough changes. A 'significant' change can mean a driver, a new example, or anything like that.

After the project becomes mature enough, we will upstream PRs directly.

This will also enable us to see if we have merge issues with upstream before we create the PR.

# **⚠️ DO NOT MERGE THIS PR**